### PR TITLE
Revert "BoardConfig: Set 'systempart' & 'datapart' kernel cmdline opt…

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -61,8 +61,6 @@ TARGET_USES_64_BIT_BINDER := true
 
 # Kernel
 BOARD_KERNEL_CMDLINE := androidboot.hardware=qcom user_debug=31 msm_rtb.filter=0x37 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 boot_cpus=0-7 selinux=permissive
-BOARD_KERNEL_CMDLINE += systempart=/dev/disk/by-partlabel/system
-BOARD_KERNEL_CMDLINE += datapart=/dev/disk/by-partlabel/userdata
 BOARD_KERNEL_BASE := 0x00000000
 BOARD_KERNEL_PAGESIZE := 4096
 BOARD_KERNEL_TAGS_OFFSET := 0x00000100


### PR DESCRIPTION
…ions "

This reverts commit 46552eadda7f95b94a3f54406af9aa3f278b8cb3.

It breaks halium-boot to mount oneplus2 root device, so needed to be reworked